### PR TITLE
Explicitly declaring dependencies 

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,6 +11,8 @@ Package.describe({
 Package.onUse(function (api) {
     api.versionsFrom('1.1.0.2');
 
+    api.use('underscore');
+    api.use('check');
     api.use('mongo');
     api.use('jalik:ufs@0.2.4');
 


### PR DESCRIPTION
Fixes errors when referencing from another Meteor package, e.g.:
![screen shot 2015-10-16 at 10 40 26](https://cloud.githubusercontent.com/assets/190883/10543171/4844e742-73f3-11e5-8831-0722f8725788.png)
